### PR TITLE
Fix for python3, latest librosa and pyin vamp plugin

### DIFF
--- a/8bits.py
+++ b/8bits.py
@@ -1,5 +1,8 @@
-import librosa
+#!/usr/bin/env python3
+
 import argparse
+import librosa
+import soundfile
 from py8bits import core
 
 
@@ -19,6 +22,6 @@ if __name__ == '__main__':
 
     audio, fs = librosa.load(args.audio_path, args.sample_rate, mono=False)
     audio_8bit = core.convert(audio, fs=fs, v_centered=args.c, block_size=args.block_size, step_size=args.step_size)
-    librosa.output.write_wav(args.output_path, audio_8bit, sr=int(fs), norm=False)
+    soundfile.write(args.output_path, audio_8bit, samplerate=int(fs))
 
 

--- a/py8bits/pyin.py
+++ b/py8bits/pyin.py
@@ -46,7 +46,7 @@ def pYIN(audio, fs=44100., hop_size=1024, block_size=2048, step_size=1024,
         'onsetsensitivity'  : onsetsensitivity,
     }
 
-    data = vamp.collect(audio, fs, 'pyin:pyin', 'notes', 
+    data = vamp.collect(audio, fs, 'vamp-pyin-f0:pyin', 'notes', 
                         parameters=parameters, block_size=block_size, step_size=step_size)['list']
     actl  = proc_frame(data, length, fs=fs, hop_size=hop_size)
 


### PR DESCRIPTION
**Changes**
- added `soundfile` module dependency (`output` module [deprecated](https://github.com/librosa/librosa/issues/917) in `librosa >= 0.8`);
- changed *pyin* plugin name to reflect changes in `vamp-pyin-f0-plugin`.

Don't remember how it was before, but now the program works using latest version of everything.

I also made a stub AUR package, but it will need the program to be converted to a module to have it installed, so other MR will follow.